### PR TITLE
feat(events): implement CRUD operations for events and add error hand…

### DIFF
--- a/backend/doc/swagger.yaml
+++ b/backend/doc/swagger.yaml
@@ -456,7 +456,7 @@ paths:
             schema:
               $ref: '#/components/schemas/EventCreateRequest'
       responses:
-        '201':
+        '200':
           description: Event created successfully
           content:
             application/json:

--- a/backend/doc/swagger.yaml
+++ b/backend/doc/swagger.yaml
@@ -403,6 +403,141 @@ paths:
         '500':
           description: Internal server error
 
+  /events:
+    get:
+      summary: Get all events
+      tags:
+        - Events
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 10
+      responses:
+        '200':
+          description: List of events
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Event'
+                  pagination:
+                    type: object
+                    properties:
+                      page:
+                        type: integer
+                      limit:
+                        type: integer
+                      total:
+                        type: integer
+        '500':
+          description: Internal server error
+
+    post:
+      summary: Create a new event
+      tags:
+        - Events
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EventCreateRequest'
+      responses:
+        '201':
+          description: Event created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+        '400':
+          description: Bad request
+        '500':
+          description: Internal server error
+
+  /events/{id}:
+    get:
+      summary: Get an event by ID
+      tags:
+        - Events
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Event found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+        '404':
+          description: Event not found
+        '500':
+          description: Internal server error
+
+    put:
+      summary: Update an event by ID
+      tags:
+        - Events
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EventUpdateRequest'
+      responses:
+        '200':
+          description: Event updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+        '400':
+          description: Invalid input
+        '404':
+          description: Event not found
+        '500':
+          description: Internal server error
+
+    delete:
+      summary: Delete an event by ID
+      tags:
+        - Events
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Event deleted successfully
+        '404':
+          description: Event not found
+        '500':
+          description: Internal server error
+
 components:
   securitySchemes:
     bearerAuth:
@@ -648,3 +783,64 @@ components:
           format: url
         description:
           type: string
+
+    Event:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        description:
+          type: string
+        location:
+          type: string
+          nullable: true
+        start_date:
+          type: string
+          format: date-time
+        end_date:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    EventCreateRequest:
+      type: object
+      required:
+        - title
+        - start_date
+        - end_date
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        location:
+          type: string
+        start_date:
+          type: string
+          format: date-time
+        end_date:
+          type: string
+          format: date-time
+
+    EventUpdateRequest:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        location:
+          type: string
+        start_date:
+          type: string
+          format: date-time
+        end_date:
+          type: string
+          format: date-time

--- a/backend/src/controllers/event.js
+++ b/backend/src/controllers/event.js
@@ -1,0 +1,78 @@
+const ApiResponse = require('@utils/response');
+const customErrors = require('@errors/customErrors');
+const EventService = require('@services/user');
+
+class Event {
+    static async getAllEvents(req, res) {
+        try {
+            const page = parseInt(req.query.page) || 1;
+            const limit = parseInt(req.query.limit) || undefined;
+
+            const result = await EventService.getAll({ page, limit });
+
+            return ApiResponse.paginated(res, result.events, result.page, result.limit, result.total);
+        } catch (error) {
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async getEventById(req, res) {
+        try {
+            const id = parseInt(req.params.id);
+            const event = await EventService.getById(id);
+
+            return ApiResponse.success(res, event);
+        } catch (error) {
+            if (error instanceof customErrors.EventNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'EVENT_NOT_FOUND');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async createEvent(req, res) {
+        try {
+            const data = req.body;
+            const event = await EventService.create(data);
+
+            return ApiResponse.success(res, event);
+        } catch (error) {
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async updateEvent(req, res) {
+        try {
+            const id = parseInt(req.params.id);
+            const data = req.body;
+
+            await EventService.update(id, data);
+
+            return ApiResponse.success(res, null, 'Event updated successfully');
+        } catch (error) {
+            if (error instanceof customErrors.EventNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'EVENT_NOT_FOUND');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async deleteEvent(req, res) {
+        try {
+            const id = parseInt(req.params.id);
+            await EventService.delete(id);
+
+            return ApiResponse.success(res, null, 'Event deleted successfully');
+        } catch (error) {
+            if (error instanceof customErrors.EventNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'EVENT_NOT_FOUND');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+}
+
+module.exports = Event;

--- a/backend/src/controllers/event.js
+++ b/backend/src/controllers/event.js
@@ -1,6 +1,6 @@
 const ApiResponse = require('@utils/response');
 const customErrors = require('@errors/customErrors');
-const EventService = require('@services/user');
+const EventService = require('@services/event');
 
 class Event {
     static async getAllEvents(req, res) {

--- a/backend/src/errors/customErrors.js
+++ b/backend/src/errors/customErrors.js
@@ -43,6 +43,15 @@ class ProjectNotFoundError extends Error {
     }
 }
 
+// --- Event errors ---
+
+class EventNotFoundError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'EventNotFoundError';
+    }
+}
+
 // --- conflict errors ---
 
 class ConflictError extends Error {
@@ -58,5 +67,6 @@ module.exports = {
     CompanyNotFoundError,
     StartupNotFoundError,
     ProjectNotFoundError,
+    EventNotFoundError,
     ConflictError
 }

--- a/backend/src/repositories/event.js
+++ b/backend/src/repositories/event.js
@@ -1,0 +1,44 @@
+const prisma = require('@config/prisma');
+
+class Event {
+    static countAll() {
+        return prisma.events.count();
+    }
+
+    static getAllPaginated({ skip, take }) {
+        return prisma.events.findMany({
+            skip,
+            take,
+            orderBy: {
+                created_at: 'desc'
+            }
+        });
+    }
+
+    static async getById(id) {
+        return prisma.events.findUnique({
+            where: { id }
+        });
+    }
+
+    static async create(data) {
+        return prisma.events.create({
+            data
+        });
+    }
+
+    static async update(id, data) {
+        return prisma.events.update({
+            where: { id },
+            data
+        });
+    }
+
+    static async delete(id) {
+        return prisma.events.delete({
+            where: { id }
+        });
+    }
+}
+
+module.exports = Event;

--- a/backend/src/routes/event.js
+++ b/backend/src/routes/event.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const EventController = require('@controllers/event');
+
+router.get('/', EventController.getAllEvents);
+router.get('/:id', EventController.getEventById);
+router.post('/', EventController.createEvent);
+router.put('/:id', EventController.updateEvent);
+router.delete('/:id', EventController.deleteEvent);
+
+module.exports = router;

--- a/backend/src/services/event.js
+++ b/backend/src/services/event.js
@@ -32,7 +32,7 @@ class Event {
             throw new customErrors.EventNotFoundError('Event not found');
         }
 
-        await EventRepository.update(id, data);
+        return await EventRepository.update(id, data);
     }
 
     static async delete(id) {

--- a/backend/src/services/event.js
+++ b/backend/src/services/event.js
@@ -1,0 +1,48 @@
+const config = require('@config/index');
+const customErrors = require('@errors/customErrors');
+const EventRepository = require('@repositories/event');
+
+class Event {
+    static async getAll({ page, limit }) {
+        const safeLimit = Math.min(limit, config.pagination.maxLimit);
+        const offset = (page - 1) * safeLimit;
+
+        const total = await EventRepository.countAll();
+        const events = await EventRepository.getAllPaginated({ skip: offset, take: safeLimit });
+
+        return { events, total, page, limit: safeLimit };
+    }
+
+    static async getById(id) {
+        const eventData = await EventRepository.getById(id);
+        if (!eventData) {
+            throw new customErrors.EventNotFoundError('Event not found');
+        }
+
+        return eventData;
+    }
+
+    static async create(data) {
+        return EventRepository.create(data);
+    }
+
+    static async update(id, data) {
+        const existing = await EventRepository.getById(id);
+        if (!existing) {
+            throw new customErrors.EventNotFoundError('Event not found');
+        }
+
+        await EventRepository.update(id, data);
+    }
+
+    static async delete(id) {
+        const existing = await EventRepository.getById(id);
+        if (!existing) {
+            throw new customErrors.EventNotFoundError('Event not found');
+        }
+
+        await EventRepository.delete(id);
+    }
+}
+
+module.exports = Event;


### PR DESCRIPTION
This pull request adds full CRUD (Create, Read, Update, Delete) support for events to the backend API. It introduces new endpoints, controller logic, service and repository layers, error handling, and updates the OpenAPI documentation to describe the new resources and operations.

### API and Documentation

* Added `/events` and `/events/{id}` endpoints to the OpenAPI spec in `swagger.yaml`, supporting listing, creating, retrieving, updating, and deleting events with proper request/response schemas and pagination.
* Defined new schemas for `Event`, `EventCreateRequest`, and `EventUpdateRequest` in the OpenAPI documentation for consistent API contract.

### Backend Implementation

* Implemented `EventController` (`backend/src/controllers/event.js`) with methods for all CRUD operations, including error handling for not found cases.
* Added `EventService` (`backend/src/services/event.js`) to encapsulate business logic, including pagination and validation for event existence before update/delete.
* Created `EventRepository` (`backend/src/repositories/event.js`) for database access, supporting paginated queries and all CRUD operations on events.

### Routing and Error Handling

* Added new routes for events in `backend/src/routes/event.js` mapping HTTP verbs to controller actions.
* Introduced `EventNotFoundError` in custom errors for consistent error handling when events are not found. [[1]](diffhunk://#diff-6f694d17b70c4049f402321cfab0654e029f0f268e0d47769f961283e9a52f77R46-R54) [[2]](diffhunk://#diff-6f694d17b70c4049f402321cfab0654e029f0f268e0d47769f961283e9a52f77R70)