### PR TITLE
feat(news): implement CRUD operations for news and add error handling

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -22,6 +22,8 @@ app.use('/users', require('@routes/user'));
 app.use('/projects', require('@routes/project'));
 app.use('/auth', require('@routes/auth'));
 app.use('/startups', require('@routes/startup'));
+app.use('/events', require('@routes/event'));
+app.use('/news', require('@routes/news'));
 
 app.get('/', (req, res) => {
     res.send('Hello World !');

--- a/backend/doc/swagger.yaml
+++ b/backend/doc/swagger.yaml
@@ -538,6 +538,133 @@ paths:
         '500':
           description: Internal server error
 
+  /news:
+    get:
+      summary: Get all news
+      tags:
+        - News
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 10
+      responses:
+        '200':
+          description: List of news
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/News'
+                  pagination:
+                    type: object
+                    properties:
+                      page:
+                        type: integer
+                      limit:
+                        type: integer
+                      total:
+                        type: integer
+        '500':
+          description: Internal server error
+
+    post:
+      summary: Create a news item
+      tags:
+        - News
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewsCreateRequest'
+      responses:
+        '201':
+          description: News created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/News'
+        '400':
+          description: Bad request
+
+  /news/{id}:
+    get:
+      summary: Get a news item by ID
+      tags:
+        - News
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: News found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/News'
+        '404':
+          description: News not found
+
+    put:
+      summary: Update a news item by ID
+      tags:
+        - News
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewsUpdateRequest'
+      responses:
+        '200':
+          description: News updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/News'
+        '400':
+          description: Bad request
+        '404':
+          description: News not found
+
+    delete:
+      summary: Delete a news item by ID
+      tags:
+        - News
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: News deleted successfully
+        '404':
+          description: News not found
+
 components:
   securitySchemes:
     bearerAuth:
@@ -842,5 +969,58 @@ components:
           type: string
           format: date-time
         end_date:
+          type: string
+          format: date-time
+
+    News:
+      type: object
+      properties:
+        id:
+          type: integer
+        company_id:
+          type: integer
+        title:
+          type: string
+        description:
+          type: string
+        location:
+          type: string
+        date:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+
+    NewsCreateRequest:
+      type: object
+      required:
+        - company_id
+        - title
+        - description
+        - date
+      properties:
+        company_id:
+          type: integer
+        title:
+          type: string
+        description:
+          type: string
+        location:
+          type: string
+        date:
+          type: string
+          format: date-time
+
+    NewsUpdateRequest:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        location:
+          type: string
+        date:
           type: string
           format: date-time

--- a/backend/doc/swagger.yaml
+++ b/backend/doc/swagger.yaml
@@ -591,7 +591,7 @@ paths:
             schema:
               $ref: '#/components/schemas/NewsCreateRequest'
       responses:
-        '201':
+        '200':
           description: News created successfully
           content:
             application/json:
@@ -660,8 +660,8 @@ paths:
           schema:
             type: integer
       responses:
-        '204':
-          description: News deleted successfully
+        '200':
+            description: News deleted successfully
         '404':
           description: News not found
 

--- a/backend/src/controllers/news.js
+++ b/backend/src/controllers/news.js
@@ -38,10 +38,6 @@ class News {
 
             return ApiResponse.success(res, news);
         } catch (error) {
-            if (error instanceof customErrors.NewsNotFoundError) {
-                return ApiResponse.notFound(res, error.message, 'NEWS_NOT_FOUND');
-            }
-
             return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
         }
     }

--- a/backend/src/controllers/news.js
+++ b/backend/src/controllers/news.js
@@ -1,0 +1,82 @@
+const ApiResponse = require('@utils/response');
+const customErrors = require('@errors/customErrors');
+const NewsService = require('@services/news');
+
+class News {
+    static async getAllNews(req, res) {
+        try {
+            const page = parseInt(req.query.page) || 1;
+            const limit = parseInt(req.query.limit) || undefined;
+
+            const result = await NewsService.getAll({ page, limit });
+
+            return ApiResponse.paginated(res, result.news, result.page, result.limit, result.total);
+        } catch (error) {
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async getNewById(req, res) {
+        try {
+            const id = parseInt(req.params.id);
+            const news = await NewsService.getById(id);
+
+            return ApiResponse.success(res, news);
+        } catch (error) {
+            if (error instanceof customErrors.NewsNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'NEWS_NOT_FOUND');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async createNew(req, res) {
+        try {
+            const data = req.body;
+            const news = await NewsService.create(data);
+
+            return ApiResponse.success(res, news);
+        } catch (error) {
+            if (error instanceof customErrors.NewsNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'NEWS_NOT_FOUND');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async updateNew(req, res) {
+        try {
+            const id = parseInt(req.params.id);
+            const data = req.body;
+
+            await NewsService.update(id, data);
+
+            return ApiResponse.success(res, null, 'News updated successfully');
+        } catch (error) {
+            if (error instanceof customErrors.NewsNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'NEWS_NOT_FOUND');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async deleteNew(req, res) {
+        try {
+            const id = parseInt(req.params.id);
+            await NewsService.delete(id);
+
+            return ApiResponse.success(res, null, 'News deleted successfully');
+        } catch (error) {
+            if (error instanceof customErrors.NewsNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'NEWS_NOT_FOUND');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+}
+
+module.exports = News;

--- a/backend/src/errors/customErrors.js
+++ b/backend/src/errors/customErrors.js
@@ -52,6 +52,15 @@ class EventNotFoundError extends Error {
     }
 }
 
+// --- News errors ---
+
+class NewsNotFoundError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'NewsNotFoundError';
+    }
+}
+
 // --- conflict errors ---
 
 class ConflictError extends Error {
@@ -68,5 +77,6 @@ module.exports = {
     StartupNotFoundError,
     ProjectNotFoundError,
     EventNotFoundError,
+    NewsNotFoundError,
     ConflictError
 }

--- a/backend/src/repositories/news.js
+++ b/backend/src/repositories/news.js
@@ -1,0 +1,69 @@
+const prisma = require('@config/prisma');
+
+class News {
+    static countAll() {
+        return prisma.news.count();
+    }
+
+    static getAllPaginated({ skip, take }) {
+        return prisma.news.findMany({
+            skip,
+            take,
+            include: {
+                Companies: {
+                    include: {
+                        Accounts: true
+                    }
+                }
+            },
+            orderBy: {
+                Companies: {
+                    Accounts: {
+                        created_at: 'asc'
+                    }
+                }
+            }
+        });
+    }
+
+    static async getById(id) {
+        return prisma.news.findUnique({
+            where: { id },
+            include: {
+                Companies: {
+                    include: {
+                        Accounts: true
+                    }
+                }
+            }
+        });
+    }
+
+    static async create({ company_id, title, description, location, date }) {
+        return prisma.news.create({
+            data: {
+                company_id,
+                title,
+                description,
+                location,
+                date,
+                created_at: new Date()
+            }
+        });
+    }
+
+    static async update(id, data) {
+        return prisma.news.update({
+            where: { id },
+            data
+        });
+    }
+
+    static async delete(id) {
+        return prisma.news.delete({
+            where: { id }
+        });
+    }
+}
+
+module.exports = News;

--- a/backend/src/repositories/news.js
+++ b/backend/src/repositories/news.js
@@ -39,14 +39,13 @@ class News {
         });
     }
 
-    static async create({ company_id, title, description, location, date }) {
+    static async create({ company_id, title, description, location }) {
         return prisma.news.create({
             data: {
                 company_id,
                 title,
                 description,
                 location,
-                date,
                 created_at: new Date()
             }
         });

--- a/backend/src/routes/news.js
+++ b/backend/src/routes/news.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const NewsController = require('@controllers/news');
+
+router.get('/', NewsController.getAllNews);
+router.get('/:id', NewsController.getNewById);
+router.post('/', NewsController.createNew);
+router.put('/:id', NewsController.updateNew);
+router.delete('/:id', NewsController.deleteNew);
+
+module.exports = router;

--- a/backend/src/services/news.js
+++ b/backend/src/services/news.js
@@ -1,0 +1,58 @@
+const config = require('@config/index');
+const customErrors = require('@errors/customErrors');
+const NewsRepository = require('@repositories/news');
+
+class News {
+    static async getAll({ page, limit }) {
+        const safeLimit = Math.min(limit, config.pagination.maxLimit);
+        const offset = (page - 1) * safeLimit;
+
+        const total = await NewsRepository.countAll();
+        const news = await NewsRepository.getAllPaginated({ skip: offset, take: safeLimit });
+
+        return { news, total, page, limit: safeLimit };
+    }
+
+    static async getById(id) {
+        const newsItem = await NewsRepository.getById(id);
+        if (!newsItem) {
+            throw new customErrors.NewsNotFoundError('News not found');
+        }
+
+        return newsItem;
+    }
+
+    static async create(data) {
+        return await NewsRepository.create({
+            company_id: data.company_id,
+            title: data.title,
+            description: data.description,
+            location: data.location
+        });
+    }
+
+    static async update(id, data) {
+        const newsItem = await NewsRepository.getById(id);
+        if (!newsItem) {
+            throw new customErrors.NewsNotFoundError('News not found');
+        }
+
+        const updateData = {};
+        if (data.title) updateData.title = data.title;
+        if (data.description) updateData.description = data.description;
+        if (data.location) updateData.location = data.location;
+
+        return await NewsRepository.update(id, updateData);
+    }
+
+    static async delete(id) {
+        const newsItem = await NewsRepository.getById(id);
+        if (!newsItem) {
+            throw new customErrors.NewsNotFoundError('News not found');
+        }
+
+        return await NewsRepository.delete(id);
+    }
+}
+
+module.exports = News;


### PR DESCRIPTION
This pull request adds a complete CRUD (Create, Read, Update, Delete) API for managing news items in the backend. It introduces new routes, controllers, services, repository logic, error handling, and updates the Swagger documentation to describe the new endpoints and schemas. The changes are grouped below by theme.

**API and Routing**

* Added new routes for news management in `backend/app.js` and created the route handler in `backend/src/routes/news.js`, enabling endpoints for listing, retrieving, creating, updating, and deleting news items. [[1]](diffhunk://#diff-57fcf3bf0ff2ec3604e842595d8ac0b6a43665dac4d20b3da0136bd02dc36cd7R25-R26) [[2]](diffhunk://#diff-6f3bb89088b073d08f188b71c60635f435a055bbd248dcd052cd45ea1e1de3e6R1-R11)

**Controllers and Services**

* Implemented `News` controller (`backend/src/controllers/news.js`) and service (`backend/src/services/news.js`) to handle business logic and API responses for all news operations, including pagination and error handling. [[1]](diffhunk://#diff-80f228cf215475453ee418a096fad0f4d398022277540120d5d7299aecd5c5daR1-R82) [[2]](diffhunk://#diff-92b90df9507a3e3d625ed2c72bfcf5a06474fd60a1c6ccc31d0d5e998c3bd09cR1-R58)

**Repository Layer**

* Added a repository class in `backend/src/repositories/news.js` for database access related to news, including paginated queries and CRUD operations.

**Error Handling**

* Introduced a custom error class `NewsNotFoundError` in `backend/src/errors/customErrors.js` to handle cases where a news item is not found, and registered it for use across the service and controller layers. [[1]](diffhunk://#diff-6f694d17b70c4049f402321cfab0654e029f0f268e0d47769f961283e9a52f77R55-R63) [[2]](diffhunk://#diff-6f694d17b70c4049f402321cfab0654e029f0f268e0d47769f961283e9a52f77R80)

**Documentation**

* Updated Swagger documentation in `backend/doc/swagger.yaml` to describe the new `/news` endpoints (GET, POST, PUT, DELETE), their parameters, responses, and added the necessary schemas for news objects and request payloads. [[1]](diffhunk://#diff-13c2549e884e92753ded3dac08f3755f8a9408eaf37d4e5231d0b52533a4cb61R541-R667) [[2]](diffhunk://#diff-13c2549e884e92753ded3dac08f3755f8a9408eaf37d4e5231d0b52533a4cb61R974-R1026)