### PR TITLE
feat(sectors): implement CRUD operations for sectors

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -24,6 +24,7 @@ app.use('/auth', require('@routes/auth'));
 app.use('/startups', require('@routes/startup'));
 app.use('/events', require('@routes/event'));
 app.use('/news', require('@routes/news'));
+app.use('/sectors', require('@routes/sector'));
 
 app.get('/', (req, res) => {
     res.send('Hello World !');

--- a/backend/doc/swagger.yaml
+++ b/backend/doc/swagger.yaml
@@ -665,6 +665,135 @@ paths:
         '404':
           description: News not found
 
+  /sectors:
+    get:
+      summary: Get all sectors
+      tags:
+        - Sectors
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 10
+      responses:
+        '200':
+          description: List of sectors
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Sector'
+                  pagination:
+                    type: object
+                    properties:
+                      page:
+                        type: integer
+                      limit:
+                        type: integer
+                      total:
+                        type: integer
+        '500':
+          description: Internal server error
+
+    post:
+      summary: Create a new sector
+      tags:
+        - Sectors
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SectorCreateRequest'
+      responses:
+        '201':
+          description: Sector created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sector'
+        '500':
+          description: Internal server error
+
+  /sectors/{id}:
+    get:
+      summary: Get a sector by ID
+      tags:
+        - Sectors
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Sector found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sector'
+        '404':
+          description: Sector not found
+
+    put:
+      summary: Update a sector by ID
+      tags:
+        - Sectors
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SectorUpdateRequest'
+      responses:
+        '200':
+          description: Sector updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sector'
+        '404':
+          description: Sector not found
+        '500':
+          description: Internal server error
+
+    delete:
+      summary: Delete a sector by ID
+      tags:
+        - Sectors
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Sector deleted successfully
+        '404':
+          description: Sector not found
+        '500':
+          description: Internal server error
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1024,3 +1153,49 @@ components:
         date:
           type: string
           format: date-time
+
+    Sector:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Unique sector identifier
+        name:
+          type: string
+          description: Sector name
+        description:
+          type: string
+          nullable: true
+          description: Optional sector description
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp of creation
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp of last update
+
+    SectorCreateRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Sector name
+        description:
+          type: string
+          nullable: true
+          description: Optional sector description
+
+    SectorUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Sector name
+        description:
+          type: string
+          nullable: true
+          description: Optional sector description

--- a/backend/src/controllers/sector.js
+++ b/backend/src/controllers/sector.js
@@ -1,0 +1,79 @@
+const ApiResponse = require('@utils/response');
+const customErrors = require('@errors/customErrors');
+const SectorService = require('@services/sector');
+
+class Sector {
+    static async getAllSectors(req, res) {
+        try {
+            const page = parseInt(req.query.page) || 1;
+            const limit = parseInt(req.query.limit) || undefined;
+
+            const result = await SectorService.getAll({ page, limit });
+
+            return ApiResponse.paginated(res, result.sectors, result.page, result.limit, result.total);
+        } catch (error) {
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async getSectorById(req, res) {
+        try {
+            const id = parseInt(req.params.id);
+            const sector = await SectorService.getById(id);
+
+            return ApiResponse.success(res, sector);
+        } catch (error) {
+            if (error instanceof customErrors.SectorNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'SECTOR_NOT_FOUND');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async createSector(req, res) {
+        try {
+            const data = req.body;
+            const sector = await SectorService.create(data);
+
+            return ApiResponse.success(res, sector);
+        } catch (error) {
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async updateSector(req, res) {
+        try {
+            const id = parseInt(req.params.id);
+            const data = req.body;
+
+            await SectorService.update(id, data);
+
+            return ApiResponse.success(res, null, 'Sector updated successfully');
+        } catch (error) {
+            if (error instanceof customErrors.SectorNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'SECTOR_NOT_FOUND');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async deleteSector(req, res) {
+        try {
+            const id = parseInt(req.params.id);
+
+            await SectorService.delete(id);
+
+            return ApiResponse.success(res, null, 'Sector deleted successfully');
+        } catch (error) {
+            if (error instanceof customErrors.SectorNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'SECTOR_NOT_FOUND');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+}
+
+module.exports = Sector;

--- a/backend/src/errors/customErrors.js
+++ b/backend/src/errors/customErrors.js
@@ -61,6 +61,15 @@ class NewsNotFoundError extends Error {
     }
 }
 
+// --- Sector errors ---
+
+class SectorNotFoundError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'SectorNotFoundError';
+    }
+}
+
 // --- conflict errors ---
 
 class ConflictError extends Error {
@@ -78,5 +87,6 @@ module.exports = {
     ProjectNotFoundError,
     EventNotFoundError,
     NewsNotFoundError,
+    SectorNotFoundError,
     ConflictError
 }

--- a/backend/src/repositories/sector.js
+++ b/backend/src/repositories/sector.js
@@ -1,0 +1,50 @@
+const prisma = require('@config/prisma');
+
+class Sector {
+    static async countAll() {
+        return prisma.sectors.count();
+    }
+
+    static async getAllPaginated({ skip, take }) {
+        return prisma.sectors.findMany({
+            skip,
+            take,
+            orderBy: {
+                id: 'asc'
+            }
+        });
+    }
+
+    static async getById(id) {
+        return prisma.sectors.findUnique({
+            where: { id }
+        });
+    }
+
+    static async getByName(name) {
+        return prisma.sectors.findUnique({
+            where: { name }
+        });
+    }
+
+    static async create(data) {
+        return prisma.sectors.create({
+            data
+        });
+    }
+
+    static async update(id, data) {
+        return prisma.sectors.update({
+            where: { id },
+            data
+        });
+    }
+
+    static async delete(id) {
+        return prisma.sectors.delete({
+            where: { id }
+        });
+    }
+}
+
+module.exports = Sector;

--- a/backend/src/routes/sector.js
+++ b/backend/src/routes/sector.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const SectorController = require('@controllers/sector');
+
+router.get('/', SectorController.getAllSectors);
+router.get('/:id', SectorController.getSectorById);
+router.post('/', SectorController.createSector);
+router.put('/:id', SectorController.updateSector);
+router.delete('/:id', SectorController.deleteSector);
+
+module.exports = router;

--- a/backend/src/services/sector.js
+++ b/backend/src/services/sector.js
@@ -1,0 +1,58 @@
+const config = require('@config/index');
+const customErrors = require('@errors/customErrors');
+const SectorRepository = require('@repositories/sector');
+
+class Sector {
+    static async getAll({ page, limit }) {
+        const safeLimit = Math.min(limit, config.pagination.maxLimit);
+        const offset = (page - 1) * safeLimit;
+
+        const total = await SectorRepository.countAll();
+        const sectors = await SectorRepository.getAllPaginated({ skip: offset, take: safeLimit });
+
+        return { sectors, total, page, limit: safeLimit };
+    }
+
+    static async getById(id) {
+        const sectorData = await SectorRepository.getById(id);
+        if (!sectorData) {
+            throw new customErrors.SectorNotFoundError('Sector not found');
+        }
+
+        return sectorData;
+    }
+
+    static async create(data) {
+        const existing = await SectorRepository.getByName(data.name);
+        if (existing) {
+            throw new customErrors.ConflictError('Sector name already in use');
+        }
+
+        return SectorRepository.create(data);
+    }
+
+    static async update(id, data) {
+        const existing = await SectorRepository.getById(id);
+        if (!existing) {
+            throw new customErrors.SectorNotFoundError('Sector not found');
+        }
+
+        const nameExists = await SectorRepository.getByName(data.name);
+        if (nameExists && nameExists.id !== id) {
+            throw new customErrors.ConflictError('Sector name already in use');
+        }
+
+        return await SectorRepository.update(id, data);
+    }
+
+    static async delete(id) {
+        const existing = await SectorRepository.getById(id);
+        if (!existing) {
+            throw new customErrors.SectorNotFoundError('Sector not found');
+        }
+
+        await SectorRepository.delete(id);
+    }
+}
+
+module.exports = Sector;


### PR DESCRIPTION
This pull request introduces a new "Sector" resource to the backend API, enabling CRUD operations for sectors. The implementation includes new routes, controller logic, service and repository layers, error handling, and Swagger documentation updates.

### Sector API Implementation

* Added new routes in `backend/src/routes/sector.js` for listing, retrieving, creating, updating, and deleting sectors, and registered these routes in `backend/app.js`. [[1]](diffhunk://#diff-fd5e4c9d21190bd3e1745dd763e6a22e1fd195c641ddd2ad7b5b8b4334f6e1edR1-R11) [[2]](diffhunk://#diff-57fcf3bf0ff2ec3604e842595d8ac0b6a43665dac4d20b3da0136bd02dc36cd7R27)
* Implemented the controller logic in `backend/src/controllers/sector.js` to handle all sector-related API requests, including error handling for not found and conflict cases.
* Created the service layer in `backend/src/services/sector.js` to manage business logic, including pagination, uniqueness checks, and error propagation.
* Added the repository layer in `backend/src/repositories/sector.js` for database interactions using Prisma, supporting all CRUD operations.

### Error Handling Enhancements

* Introduced a new custom error class `SectorNotFoundError` in `backend/src/errors/customErrors.js` and integrated it into the error handling flow for sector operations. [[1]](diffhunk://#diff-6f694d17b70c4049f402321cfab0654e029f0f268e0d47769f961283e9a52f77R64-R72) [[2]](diffhunk://#diff-6f694d17b70c4049f402321cfab0654e029f0f268e0d47769f961283e9a52f77R90)

### API Documentation

* Updated `backend/doc/swagger.yaml` to document all sector endpoints (`/sectors`, `/sectors/{id}`) with request/response schemas, pagination, and error responses. Added new schema definitions for `Sector`, `SectorCreateRequest`, and `SectorUpdateRequest`. [[1]](diffhunk://#diff-13c2549e884e92753ded3dac08f3755f8a9408eaf37d4e5231d0b52533a4cb61R668-R796) [[2]](diffhunk://#diff-13c2549e884e92753ded3dac08f3755f8a9408eaf37d4e5231d0b52533a4cb61R1156-R1201)