### PR TITLE
feat(partner-types): implement CRUD operations for partner types

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -26,6 +26,7 @@ app.use('/events', require('@routes/event'));
 app.use('/news', require('@routes/news'));
 app.use('/sectors', require('@routes/sector'));
 app.use('/event-categories', require('@routes/eventCategory'));
+app.use('/partner-types', require('@routes/partnerType'));
 
 app.get('/', (req, res) => {
     res.send('Hello World !');

--- a/backend/doc/swagger.yaml
+++ b/backend/doc/swagger.yaml
@@ -927,6 +927,141 @@ paths:
         '500':
           description: Internal server error
 
+  /partner-types:
+    get:
+      summary: Get all partner types
+      tags:
+        - PartnerTypes
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 10
+      responses:
+        '200':
+          description: List of partner types
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PartnerType'
+                  pagination:
+                    type: object
+                    properties:
+                      page:
+                        type: integer
+                      limit:
+                        type: integer
+                      total:
+                        type: integer
+        '500':
+          description: Internal server error
+
+    post:
+      summary: Create a new partner type
+      tags:
+        - PartnerTypes
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PartnerTypeCreateRequest'
+      responses:
+        '201':
+          description: Partner type created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PartnerType'
+        '409':
+          description: Conflict - name already exists
+        '500':
+          description: Internal server error
+
+  /partner-types/{id}:
+    get:
+      summary: Get a partner type by ID
+      tags:
+        - PartnerTypes
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Partner type found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PartnerType'
+        '404':
+          description: Partner type not found
+        '500':
+          description: Internal server error
+
+    put:
+      summary: Update a partner type by ID
+      tags:
+        - PartnerTypes
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PartnerTypeUpdateRequest'
+      responses:
+        '200':
+          description: Partner type updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PartnerType'
+        '404':
+          description: Partner type not found
+        '409':
+          description: Conflict - name already exists
+        '500':
+          description: Internal server error
+
+    delete:
+      summary: Delete a partner type by ID
+      tags:
+        - PartnerTypes
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Partner type deleted successfully
+        '404':
+          description: Partner type not found
+        '500':
+          description: Internal server error
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1362,6 +1497,43 @@ components:
           nullable: true
 
     EventCategoryUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+
+    PartnerType:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    PartnerTypeCreateRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+
+    PartnerTypeUpdateRequest:
       type: object
       properties:
         name:

--- a/backend/src/controllers/partnerType.js
+++ b/backend/src/controllers/partnerType.js
@@ -1,0 +1,85 @@
+const ApiResponse = require('@utils/response');
+const customErrors = require('@errors/customErrors');
+const PartnerTypeService = require('@services/partnerType');
+
+class PartnerType {
+    static async getAllPartnerTypes(req, res) {
+        try {
+            const page = parseInt(req.query.page) || 1;
+            const limit = parseInt(req.query.limit) || undefined;
+
+            const result = await PartnerTypeService.getAll({ page, limit });
+
+            return ApiResponse.paginated(res, result.partnerTypes, result.page, result.limit, result.total);
+        } catch (error) {
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async getPartnerTypeById(req, res) {
+        try {
+            const id = parseInt(req.params.id);
+            const partnerType = await PartnerTypeService.getById(id);
+
+            return ApiResponse.success(res, partnerType);
+        } catch (error) {
+            if (error instanceof customErrors.PartnerTypeNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'PARTNER_TYPE_NOT_FOUND');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async createPartnerType(req, res) {
+        try {
+            const data = req.body;
+            const newPartnerType = await PartnerTypeService.create(data);
+
+            return ApiResponse.success(res, newPartnerType, 'Partner type created successfully');
+        } catch (error) {
+            if (error instanceof customErrors.ConflictError) {
+                return ApiResponse.conflict(res, error.message, 'PARTNER_TYPE_CONFLICT');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async updatePartnerType(req, res) {
+        try {
+            const id = parseInt(req.params.id);
+            const data = req.body;
+
+            const updatedPartnerType = await PartnerTypeService.update(id, data);
+
+            return ApiResponse.success(res, updatedPartnerType, 'Partner type updated successfully');
+        } catch (error) {
+            if (error instanceof customErrors.PartnerTypeNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'PARTNER_TYPE_NOT_FOUND');
+            }
+            if (error instanceof customErrors.ConflictError) {
+                return ApiResponse.conflict(res, error.message, 'PARTNER_TYPE_CONFLICT');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async deletePartnerType(req, res) {
+        try {
+            const id = parseInt(req.params.id);
+            await PartnerTypeService.delete(id);
+
+            return ApiResponse.success(res, null, 'Partner type deleted successfully');
+        } catch (error) {
+            if (error instanceof customErrors.PartnerTypeNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'PARTNER_TYPE_NOT_FOUND');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+}
+
+module.exports = PartnerType;

--- a/backend/src/errors/customErrors.js
+++ b/backend/src/errors/customErrors.js
@@ -79,6 +79,15 @@ class EventCategoryNotFoundError extends Error {
     }
 }
 
+// --- PartnerType errors ---
+
+class PartnerTypeNotFoundError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'PartnerTypeNotFoundError';
+    }
+}
+
 // --- conflict errors ---
 
 class ConflictError extends Error {
@@ -98,5 +107,6 @@ module.exports = {
     NewsNotFoundError,
     SectorNotFoundError,
     EventCategoryNotFoundError,
+    PartnerTypeNotFoundError,
     ConflictError
 }

--- a/backend/src/repositories/partnerType.js
+++ b/backend/src/repositories/partnerType.js
@@ -1,0 +1,50 @@
+const prisma = require('@config/prisma');
+
+class PartnerType {
+    static countAll() {
+        return prisma.partnerTypes.count();
+    }
+
+    static getAllPaginated({ skip, take }) {
+        return prisma.partnerTypes.findMany({
+            skip,
+            take,
+            orderBy: {
+                id: 'asc'
+            }
+        });
+    }
+
+    static async getById(id) {
+        return prisma.partnerTypes.findUnique({
+            where: { id }
+        });
+    }
+
+    static async getByName(name) {
+        return prisma.partnerTypes.findUnique({
+            where: { name }
+        });
+    }
+
+    static async create(data) {
+        return prisma.partnerTypes.create({
+            data
+        });
+    }
+
+    static async update(id, data) {
+        return prisma.partnerTypes.update({
+            where: { id },
+            data
+        });
+    }
+
+    static async delete(id) {
+        return prisma.partnerTypes.delete({
+            where: { id }
+        });
+    }
+}
+
+module.exports = PartnerType;

--- a/backend/src/routes/partnerType.js
+++ b/backend/src/routes/partnerType.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const PartnerTypeController = require('@controllers/partnerType');
+
+router.get('/', PartnerTypeController.getAllPartnerTypes);
+router.get('/:id', PartnerTypeController.getPartnerTypeById);
+router.post('/', PartnerTypeController.createPartnerType);
+router.put('/:id', PartnerTypeController.updatePartnerType);
+router.delete('/:id', PartnerTypeController.deletePartnerType);
+
+module.exports = router;

--- a/backend/src/services/partnerType.js
+++ b/backend/src/services/partnerType.js
@@ -1,0 +1,58 @@
+const config = require('@config/index');
+const customErrors = require('@errors/customErrors');
+const PartnerTypeRepository = require('@repositories/partnerType');
+
+class PartnerType {
+    static async getAll({ page, limit }) {
+        const safeLimit = Math.min(limit, config.pagination.maxLimit);
+        const offset = (page - 1) * safeLimit;
+
+        const total = await PartnerTypeRepository.countAll();
+        const partnerTypes = await PartnerTypeRepository.getAllPaginated({ skip: offset, take: safeLimit });
+
+        return { partnerTypes, total, page, limit: safeLimit };
+    }
+
+    static async getById(id) {
+        const partnerTypeData = await PartnerTypeRepository.getById(id);
+        if (!partnerTypeData) {
+            throw new customErrors.PartnerTypeNotFoundError('Partner type not found');
+        }
+
+        return partnerTypeData;
+    }
+
+    static async create(data) {
+        const existing = await PartnerTypeRepository.getByName(data.name);
+        if (existing) {
+            throw new customErrors.ConflictError('Partner type name already in use');
+        }
+
+        return PartnerTypeRepository.create(data);
+    }
+
+    static async update(id, data) {
+        const existing = await PartnerTypeRepository.getById(id);
+        if (!existing) {
+            throw new customErrors.PartnerTypeNotFoundError('Partner type not found');
+        }
+
+        const nameExists = await PartnerTypeRepository.getByName(data.name);
+        if (nameExists && nameExists.id !== id) {
+            throw new customErrors.ConflictError('Partner type name already in use');
+        }
+
+        return await PartnerTypeRepository.update(id, data);
+    }
+
+    static async delete(id) {
+        const existing = await PartnerTypeRepository.getById(id);
+        if (!existing) {
+            throw new customErrors.PartnerTypeNotFoundError('Partner type not found');
+        }
+
+        await PartnerTypeRepository.delete(id);
+    }
+}
+
+module.exports = PartnerType;


### PR DESCRIPTION
This pull request introduces a new "partner types" resource to the backend API, including full CRUD (Create, Read, Update, Delete) functionality, error handling, and documentation. The implementation follows established patterns for controllers, services, repositories, and routes, and updates the OpenAPI (Swagger) documentation accordingly.

**Partner Types API Implementation**

* Added a new route for `partner-types` in `app.js` to register the resource with Express.
* Created controller (`partnerType.js`), service (`partnerType.js`), and repository (`partnerType.js`) layers to handle all partner type operations: listing, retrieving by ID, creation, updating, and deletion, with appropriate error handling for not found and conflict cases. [[1]](diffhunk://#diff-3667bd0f168f8ca777fb44cfdb289d6c1a286d9630eff07e839a4950b74d5409R1-R85) [[2]](diffhunk://#diff-4756088d468651f8340ebfb52370efa16f4f3d1db711d3603c37c94937e9b9d1R1-R58) [[3]](diffhunk://#diff-aecbee710ec30b381b5b1ba0a04b0a213b0671958813cc6163f4882fe0ce8c3fR1-R50)
* Defined custom error classes for partner type not found and conflict scenarios in `customErrors.js`. [[1]](diffhunk://#diff-6f694d17b70c4049f402321cfab0654e029f0f268e0d47769f961283e9a52f77R82-R90) [[2]](diffhunk://#diff-6f694d17b70c4049f402321cfab0654e029f0f268e0d47769f961283e9a52f77R110)
* Registered the new routes for partner types in `routes/partnerType.js`, supporting GET, POST, PUT, and DELETE endpoints.

**API Documentation Updates**

* Extended the OpenAPI (Swagger) specification in `swagger.yaml` to document all `partner-types` endpoints, including request/response schemas, pagination, and error responses.
* Added new schemas for partner type objects and request payloads to the OpenAPI components section.