### PR TITLE
feat(investor-types): implement CRUD operations for investor types

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -30,6 +30,7 @@ app.use('/partner-types', require('@routes/partnerType'));
 app.use('/social-medias', require('@routes/socialMedia'));
 app.use('/investment-focus', require('@routes/investmentFocus'));
 app.use('/legal-status', require('@routes/legalStatus'));
+app.use('/investor-types', require('@routes/investorType'));
 
 app.get('/', (req, res) => {
     res.send('Hello World !');

--- a/backend/doc/swagger.yaml
+++ b/backend/doc/swagger.yaml
@@ -1455,6 +1455,137 @@ paths:
         '500':
           description: Internal server error
 
+  /investor-types:
+    get:
+      summary: Get all investor types
+      tags:
+        - InvestorType
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 10
+      responses:
+        '200':
+          description: List of investor types
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/InvestorTypes'
+                  pagination:
+                    type: object
+                    properties:
+                      page:
+                        type: integer
+                      limit:
+                        type: integer
+                      total:
+                        type: integer
+        '500':
+          description: Internal server error
+
+    post:
+      summary: Create a new investor type
+      tags:
+        - InvestorType
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InvestorTypesCreateRequest'
+      responses:
+        '201':
+          description: Investor type created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvestorTypes'
+        '409':
+          description: Conflict - name already exists
+        '500':
+          description: Internal server error
+
+  /investor-types/{id}:
+    get:
+      summary: Get investor type by ID
+      tags:
+        - InvestorType
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Investor type found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvestorTypes'
+        '404':
+          description: Not found
+        '500':
+          description: Internal server error
+
+    put:
+      summary: Update investor type by ID
+      tags:
+        - InvestorType
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InvestorTypesUpdateRequest'
+      responses:
+        '200':
+          description: Investor type updated
+        '404':
+          description: Not found
+        '409':
+          description: Conflict - name already in use
+        '500':
+          description: Internal server error
+
+    delete:
+      summary: Delete investor type by ID
+      tags:
+        - InvestorType
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Deleted successfully
+        '404':
+          description: Not found
+        '500':
+          description: Internal server error
+
 components:
   securitySchemes:
     bearerAuth:
@@ -2021,6 +2152,34 @@ components:
           type: string
 
     LegalStatusUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+
+    InvestorTypes:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    InvestorTypesCreateRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+
+    InvestorTypesUpdateRequest:
       type: object
       properties:
         name:

--- a/backend/src/controllers/investorType.js
+++ b/backend/src/controllers/investorType.js
@@ -1,0 +1,86 @@
+const ApiResponse = require('@utils/response');
+const customErrors = require('@errors/customErrors');
+const InvestorTypeService = require('@services/investorType');
+
+class InvestorType {
+    static async getAllInvestorTypes(req, res) {
+        try {
+            const page = parseInt(req.query.page) || 1;
+            const limit = parseInt(req.query.limit) || undefined;
+
+            const result = await InvestorTypeService.getAll({ page, limit });
+
+            return ApiResponse.paginated(res, result.investorTypes, result.page, result.limit, result.total);
+        } catch (error) {
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async getInvestorTypeById(req, res) {
+        try {
+            const id = parseInt(req.params.id);
+            const investorType = await InvestorTypeService.getById(id);
+
+            return ApiResponse.success(res, investorType);
+        } catch (error) {
+            if (error instanceof customErrors.InvestorTypeNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'INVESTOR_TYPE_NOT_FOUND');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async createInvestorType(req, res) {
+        try {
+            const data = req.body;
+            const investorType = await InvestorTypeService.create(data);
+
+            return ApiResponse.success(res, investorType);
+        } catch (error) {
+            if (error instanceof customErrors.ConflictError) {
+                return ApiResponse.conflict(res, error.message, 'INVESTOR_TYPE_CONFLICT');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async updateInvestorType(req, res) {
+        try {
+            const id = parseInt(req.params.id);
+            const data = req.body;
+
+            await InvestorTypeService.update(id, data);
+
+            return ApiResponse.success(res, null, 'Investor type updated successfully');
+        } catch (error) {
+            if (error instanceof customErrors.InvestorTypeNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'INVESTOR_TYPE_NOT_FOUND');
+            }
+            if (error instanceof customErrors.ConflictError) {
+                return ApiResponse.conflict(res, error.message, 'INVESTOR_TYPE_CONFLICT');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+
+    static async deleteInvestorType(req, res) {
+        try {
+            const id = parseInt(req.params.id);
+
+            await InvestorTypeService.delete(id);
+
+            return ApiResponse.success(res, null, 'Investor type deleted successfully');
+        } catch (error) {
+            if (error instanceof customErrors.InvestorTypeNotFoundError) {
+                return ApiResponse.notFound(res, error.message, 'INVESTOR_TYPE_NOT_FOUND');
+            }
+
+            return ApiResponse.error(res, 'Internal error', 'INTERNAL_ERROR', 550, error);
+        }
+    }
+}
+
+module.exports = InvestorType;

--- a/backend/src/errors/customErrors.js
+++ b/backend/src/errors/customErrors.js
@@ -115,6 +115,15 @@ class LegalStatusNotFoundError extends Error {
     }
 }
 
+// --- Investor Type errors ---
+
+class InvestorTypeNotFoundError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'InvestorTypeNotFoundError';
+    }
+}
+
 // --- conflict errors ---
 
 class ConflictError extends Error {
@@ -138,5 +147,6 @@ module.exports = {
     SocialMediaNotFoundError,
     InvestmentFocusNotFoundError,
     LegalStatusNotFoundError,
+    InvestorTypeNotFoundError,
     ConflictError
 }

--- a/backend/src/repositories/investorType.js
+++ b/backend/src/repositories/investorType.js
@@ -1,0 +1,50 @@
+const prisma = require('@config/prisma');
+
+class InvestorType {
+    static countAll() {
+        return prisma.investorTypes.count();
+    }
+
+    static getAllPaginated({ skip, take }) {
+        return prisma.investorTypes.findMany({
+            skip,
+            take,
+            orderBy: {
+                id: 'asc'
+            }
+        });
+    }
+
+    static async getById(id) {
+        return prisma.investorTypes.findUnique({
+            where: { id }
+        });
+    }
+
+    static async getByName(name) {
+        return prisma.investorTypes.findUnique({
+            where: { name }
+        });
+    }
+
+    static async create(data) {
+        return prisma.investorTypes.create({
+            data
+        });
+    }
+
+    static async update(id, data) {
+        return prisma.investorTypes.update({
+            where: { id },
+            data
+        });
+    }
+
+    static async delete(id) {
+        return prisma.investorTypes.delete({
+            where: { id }
+        });
+    }
+}
+
+module.exports = InvestorType;

--- a/backend/src/routes/investorType.js
+++ b/backend/src/routes/investorType.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const InvestorTypeController = require('@controllers/investorType');
+
+router.get('/', InvestorTypeController.getAllInvestorTypes);
+router.get('/:id', InvestorTypeController.getInvestorTypeById);
+router.post('/', InvestorTypeController.createInvestorType);
+router.put('/:id', InvestorTypeController.updateInvestorType);
+router.delete('/:id', InvestorTypeController.deleteInvestorType);
+
+module.exports = router;

--- a/backend/src/services/investorType.js
+++ b/backend/src/services/investorType.js
@@ -1,0 +1,58 @@
+const config = require('@config/index');
+const customErrors = require('@errors/customErrors');
+const InvestorTypeRepository = require('@repositories/investorType');
+
+class InvestorType {
+    static async getAll({ page, limit }) {
+        const safeLimit = Math.min(limit, config.pagination.maxLimit);
+        const offset = (page - 1) * safeLimit;
+
+        const total = await InvestorTypeRepository.countAll();
+        const investorTypes = await InvestorTypeRepository.getAllPaginated({ skip: offset, take: safeLimit });
+
+        return { investorTypes, total, page, limit: safeLimit };
+    }
+
+    static async getById(id) {
+        const investorTypeData = await InvestorTypeRepository.getById(id);
+        if (!investorTypeData) {
+            throw new customErrors.InvestorTypeNotFoundError('Investor type not found');
+        }
+
+        return investorTypeData;
+    }
+
+    static async create(data) {
+        const existing = await InvestorTypeRepository.getByName(data.name);
+        if (existing) {
+            throw new customErrors.ConflictError('Investor type name already in use');
+        }
+
+        return InvestorTypeRepository.create(data);
+    }
+
+    static async update(id, data) {
+        const existing = await InvestorTypeRepository.getById(id);
+        if (!existing) {
+            throw new customErrors.InvestorTypeNotFoundError('Investor type not found');
+        }
+
+        const nameExists = await InvestorTypeRepository.getByName(data.name);
+        if (nameExists && nameExists.id !== id) {
+            throw new customErrors.ConflictError('Investor type name already in use');
+        }
+
+        return await InvestorTypeRepository.update(id, data);
+    }
+
+    static async delete(id) {
+        const existing = await InvestorTypeRepository.getById(id);
+        if (!existing) {
+            throw new customErrors.InvestorTypeNotFoundError('Investor type not found');
+        }
+
+        await InvestorTypeRepository.delete(id);
+    }
+}
+
+module.exports = InvestorType;


### PR DESCRIPTION
This pull request adds full CRUD (Create, Read, Update, Delete) support for "Investor Types" to the backend API, including new endpoints, controller logic, service and repository layers, error handling, and documentation. The changes are grouped below by theme for clarity.

**API & Documentation**

* Added `/investor-types` and `/investor-types/{id}` endpoints to the Express app and documented them in Swagger, supporting GET (list & by ID), POST (create), PUT (update), and DELETE (remove) operations, with pagination and conflict/error handling. [[1]](diffhunk://#diff-57fcf3bf0ff2ec3604e842595d8ac0b6a43665dac4d20b3da0136bd02dc36cd7R33) [[2]](diffhunk://#diff-13c2549e884e92753ded3dac08f3755f8a9408eaf37d4e5231d0b52533a4cb61R1458-R1588)

**Backend Implementation**

* Implemented the `InvestorTypeController` in `backend/src/controllers/investorType.js` to handle all CRUD operations, using consistent API responses and custom error handling.
* Created the `InvestorTypeService` in `backend/src/services/investorType.js` to manage business logic, including pagination, uniqueness checks, and error throwing for not found or conflict cases.
* Added the `InvestorTypeRepository` in `backend/src/repositories/investorType.js` for database access, including paginated queries, create, update, and delete methods.

**Routing**

* Registered the new investor type routes in `backend/src/routes/investorType.js` and wired them into the main app. [[1]](diffhunk://#diff-b89cc5a4e286a3e139f5ee43a73dd1a75c0f2919b17297c20f53dea0a4baef59R1-R11) [[2]](diffhunk://#diff-57fcf3bf0ff2ec3604e842595d8ac0b6a43665dac4d20b3da0136bd02dc36cd7R33)

**Error Handling**

* Defined a custom `InvestorTypeNotFoundError` in `backend/src/errors/customErrors.js` and integrated it into the error handling flow for investor type operations. [[1]](diffhunk://#diff-6f694d17b70c4049f402321cfab0654e029f0f268e0d47769f961283e9a52f77R118-R126) [[2]](diffhunk://#diff-6f694d17b70c4049f402321cfab0654e029f0f268e0d47769f961283e9a52f77R150)

**Swagger Schema**

* Added new Swagger schemas for investor types and request bodies, ensuring API documentation is up-to-date with the new resource.

Let me know if you want to walk through any part of the flow or discuss testing strategy for these endpoints!